### PR TITLE
feat(aspnetcore): add group-role mapping extension for authorization policies

### DIFF
--- a/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful extensions for cross-cutting concerns at Arbeidstilsynet</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.2.0</Version>
+    <Version>2.3.0-alpha.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful extensions for cross-cutting concerns at Arbeidstilsynet</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.3.0-alpha.1</Version>
+    <Version>2.3.0-alpha.2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/AspNetCore/AT.Common.AspNetCore.Publish/CHANGELOG.md
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 2.3.0
+
+### Added
+
+- feat(extensions): add extension `System.Security.Claims.ClaimsPrincipal.HasAnyAllowedGroup` for creating custom policies mapping claim groups to roles.
+
 ## 2.2.0
 
 ### Changed

--- a/AspNetCore/AT.Common.AspNetCore.Publish/CHANGELOG.md
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- feat(extensions): add extension `System.Security.Claims.ClaimsPrincipal.HasAnyAllowedGroup` for creating custom policies mapping claim groups to roles.
+- feat(extensions): add `Microsoft.Extensions.DependencyInjection.IServiceCollection.AddGroupRoleMappings` for creating custom policies mapping claim groups to roles.
 
 ## 2.2.0
 

--- a/AspNetCore/AT.Common.AspNetCore.Publish/Extensions/AuthorizationExtensions.cs
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/Extensions/AuthorizationExtensions.cs
@@ -42,6 +42,14 @@ public static class AuthorizationExtensions
         });
     }
 
+    public static void AddGroupRoleMappings(
+        this IServiceCollection services,
+        IReadOnlyDictionary<string, IEnumerable<string>> roleGroupMappings,
+        string m2mAppRole, // "access_as_application",
+        string groupClaimType = "groups",
+        string rolesClaimType = "roles"
+    ) { }
+
     private static bool HasAnyAllowedGroup(
         this ClaimsPrincipal user,
         HashSet<string> allowedGroupIds,

--- a/AspNetCore/AT.Common.AspNetCore.Publish/Extensions/AuthorizationExtensions.cs
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/Extensions/AuthorizationExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Arbeidstilsynet.Common.AspNetCore.Extensions.Extensions;
 
-internal static class AuthorizationExtensions
+public static class AuthorizationExtensions
 {
     /// <summary>
     /// Adds authorization policies based on role to group ID mappings.<br />

--- a/AspNetCore/AT.Common.AspNetCore.Publish/Extensions/AuthorizationExtensions.cs
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/Extensions/AuthorizationExtensions.cs
@@ -1,0 +1,58 @@
+using System.Security.Claims;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Arbeidstilsynet.Common.AspNetCore.Extensions.Extensions;
+
+internal static class AuthorizationExtensions
+{
+    /// <summary>
+    /// Adds authorization policies based on role to group ID mappings.<br />
+    /// This can be used to handle authorization when JWT claims have groups but not roles.<br />
+    /// Usage:<br/>
+    /// [HttpGet("foo")]<br />
+    /// [Authorize(Policy = CustomRoleName)]
+    /// </summary>
+    /// <param name="services">The service collection to add the policies to.</param>
+    /// <param name="roleGroupMappings">A dictionary mapping role names to arrays of allowed group IDs.</param>
+    /// <param name="groupClaimType">The claim type used for group IDs. Defaults to "groups".</param>
+    public static void AddGroupRoleMappings(
+        this IServiceCollection services,
+        IReadOnlyDictionary<string, IEnumerable<string>> roleGroupMappings,
+        string groupClaimType = "groups"
+    )
+    {
+        services.AddAuthorization(options =>
+        {
+            foreach (var mapping in roleGroupMappings)
+            {
+                var allowed = (mapping.Value ?? Array.Empty<string>()).ToHashSet(
+                    StringComparer.OrdinalIgnoreCase
+                );
+
+                options.AddPolicy(
+                    mapping.Key,
+                    policy =>
+                        policy
+                            .RequireAuthenticatedUser()
+                            .RequireAssertion(context =>
+                                context.User.HasAnyAllowedGroup(allowed, groupClaimType)
+                            )
+                );
+            }
+        });
+    }
+
+    private static bool HasAnyAllowedGroup(
+        this ClaimsPrincipal user,
+        HashSet<string> allowedGroupIds,
+        string groupClaimType
+    )
+    {
+        if (allowedGroupIds is null || allowedGroupIds.Count == 0)
+        {
+            return false;
+        }
+
+        return user.FindAll(groupClaimType).Select(c => c.Value).Any(allowedGroupIds.Contains);
+    }
+}

--- a/AspNetCore/AT.Common.AspNetCore.Test/Unit/AuthorizationExtensionsTests.cs
+++ b/AspNetCore/AT.Common.AspNetCore.Test/Unit/AuthorizationExtensionsTests.cs
@@ -1,0 +1,175 @@
+using System.Security.Claims;
+using Arbeidstilsynet.Common.AspNetCore.Extensions.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Arbeidstilsynet.Common.AspNetCore.Extensions.Test.Unit;
+
+public class AuthorizationExtensionsTests
+{
+    private const string PolicyName = "reader";
+    private const string DefaultGroupClaimType = "groups";
+
+    [Fact]
+    public async Task AddGroupRoleMappings_WhenUserAuthenticatedAndInAllowedGroup_Succeeds()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGroupRoleMappings(
+            new Dictionary<string, IEnumerable<string>> { [PolicyName] = ["abc"] },
+            groupClaimType: DefaultGroupClaimType
+        );
+
+        var serviceProvider = services.BuildServiceProvider();
+        var authorizationService = serviceProvider.GetRequiredService<IAuthorizationService>();
+
+        var user = CreateUser(isAuthenticated: true, (DefaultGroupClaimType, "ABC"));
+
+        // Act
+        var result = await authorizationService.AuthorizeAsync(
+            user,
+            resource: null,
+            policyName: PolicyName
+        );
+
+        // Assert
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task AddGroupRoleMappings_WhenUserAuthenticatedButNotInAllowedGroup_Fails()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGroupRoleMappings(
+            new Dictionary<string, IEnumerable<string>> { [PolicyName] = ["foo", "bar"] },
+            groupClaimType: DefaultGroupClaimType
+        );
+
+        var serviceProvider = services.BuildServiceProvider();
+        var authorizationService = serviceProvider.GetRequiredService<IAuthorizationService>();
+
+        var user = CreateUser(isAuthenticated: true, (DefaultGroupClaimType, "def"));
+
+        // Act
+        var result = await authorizationService.AuthorizeAsync(
+            user,
+            resource: null,
+            policyName: PolicyName
+        );
+
+        // Assert
+        result.Succeeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AddGroupRoleMappings_WhenUserNotAuthenticated_EvenIfInAllowedGroup_Fails()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGroupRoleMappings(
+            new Dictionary<string, IEnumerable<string>> { [PolicyName] = ["abc"] },
+            groupClaimType: DefaultGroupClaimType
+        );
+
+        var serviceProvider = services.BuildServiceProvider();
+        var authorizationService = serviceProvider.GetRequiredService<IAuthorizationService>();
+
+        var user = CreateUser(isAuthenticated: false, (DefaultGroupClaimType, "abc"));
+
+        // Act
+        var result = await authorizationService.AuthorizeAsync(
+            user,
+            resource: null,
+            policyName: PolicyName
+        );
+
+        // Assert
+        result.Succeeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AddGroupRoleMappings_WhenAllowedGroupListIsEmpty_Fails()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGroupRoleMappings(
+            new Dictionary<string, IEnumerable<string>> { [PolicyName] = Array.Empty<string>() },
+            groupClaimType: DefaultGroupClaimType
+        );
+
+        var serviceProvider = services.BuildServiceProvider();
+        var authorizationService = serviceProvider.GetRequiredService<IAuthorizationService>();
+
+        var user = CreateUser(isAuthenticated: true, (DefaultGroupClaimType, "abc"));
+
+        // Act
+        var result = await authorizationService.AuthorizeAsync(
+            user,
+            resource: null,
+            policyName: PolicyName
+        );
+
+        // Assert
+        result.Succeeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AddGroupRoleMappings_WhenCustomGroupClaimTypeIsUsed_RespectsClaimType()
+    {
+        // Arrange
+        const string customClaimType = "mygroups";
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGroupRoleMappings(
+            new Dictionary<string, IEnumerable<string>> { [PolicyName] = ["abc"] },
+            groupClaimType: customClaimType
+        );
+
+        var serviceProvider = services.BuildServiceProvider();
+        var authorizationService = serviceProvider.GetRequiredService<IAuthorizationService>();
+
+        // Has matching group id, but on the default claim type, not the configured one.
+        var user = CreateUser(isAuthenticated: true, (DefaultGroupClaimType, "abc"));
+
+        // Act
+        var result = await authorizationService.AuthorizeAsync(
+            user,
+            resource: null,
+            policyName: PolicyName
+        );
+
+        // Assert
+        result.Succeeded.ShouldBeFalse();
+
+        // Act (with matching claim type)
+        var userWithCustomClaim = CreateUser(isAuthenticated: true, (customClaimType, "abc"));
+        var result2 = await authorizationService.AuthorizeAsync(
+            userWithCustomClaim,
+            resource: null,
+            policyName: PolicyName
+        );
+
+        // Assert
+        result2.Succeeded.ShouldBeTrue();
+    }
+
+    private static ClaimsPrincipal CreateUser(
+        bool isAuthenticated,
+        params (string Type, string Value)[] claims
+    )
+    {
+        var identityClaims = claims.Select(c => new Claim(c.Type, c.Value));
+        var identity = isAuthenticated
+            ? new ClaimsIdentity(identityClaims, authenticationType: "TestAuth")
+            : new ClaimsIdentity(identityClaims);
+
+        return new ClaimsPrincipal(identity);
+    }
+}


### PR DESCRIPTION
Example usage:

```csharp
            services.AddGroupRoleMappings(
                new Dictionary<string, IEnumerable<string>>()
                {
                    {
                        MasseutsendelseAuthorization.ReaderPolicy,
                        // senders also have read access
                        [.. senderGroupIds, .. readerGroupIds]
                    },
                    { MasseutsendelseAuthorization.SenderPolicy, senderGroupIds },
                }
            );
```

NB: Client credential tokens (m2m) are not handled yet. We can add a path for checking for role `access_as_application`, but what should the API be?

```cs
    public static void AddGroupRoleMappings(
        this IServiceCollection services,
        IReadOnlyDictionary<string, IEnumerable<string>> roleGroupMappings,
        string m2mAppRole, // "access_as_application",
        string groupClaimType = "groups",
        string rolesClaimType = "roles"
    )
```