### PR TITLE
chore: move packages to nuget.org with trusted publishing

### DIFF
--- a/.github/workflows/build-pr-template.yaml
+++ b/.github/workflows/build-pr-template.yaml
@@ -35,7 +35,6 @@ jobs:
           include: |
             ${{ steps.get_parent_dir.outputs.parent_dir }}
 
-
       - name: Changes for publishing?
         uses: Arbeidstilsynet/action-check-changes@6e51077b178b819e4194f40e32bd562df0954f3f # v1
         id: check_changes_for_publishing
@@ -99,10 +98,10 @@ jobs:
 
       - name: Publish prerelease package
         if: steps.prerelease_check.outputs.is_prerelease == 'true'
-        uses: Arbeidstilsynet/action-dotnet-publish@8d282653fd85f9a26e80d4f6a4c660eb5d6c8896 # v2
+        uses: Arbeidstilsynet/action-dotnet-publish@d1cc7810946ae13e76f109fab16a07bf75ec5917 # v3
         with:
           working-directory: ${{ needs.check-and-prepare.outputs.package_path }}
-          nuget-auth-token: ${{ secrets.AZURE_DEVOPS_PUBLISH_PACKAGE_PAT }}
+          nuget-username: ${{ vars.NUGET_BOT_USERNAME }}
 
       - name: Fail if prerelease was published
         if: steps.prerelease_check.outputs.is_prerelease == 'true'

--- a/.github/workflows/build-pr-template.yaml
+++ b/.github/workflows/build-pr-template.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           name: ${{ steps.get_metadata_from_csprojectfile.outputs.name }}
           version: ${{ steps.get_metadata_from_csprojectfile.outputs.version }}
-          source-feed: AT.Public.NuGet
+          source-feed: nuget
 
       - name: Check if version is prerelease
         id: prerelease_check

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.discover.outputs.matrix) }}
     uses: ./.github/workflows/build-pr-template.yaml
-    secrets: inherit
     with:
       package-path: ${{ matrix.package }}
 

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.discover.outputs.matrix) }}
     uses: ./.github/workflows/build-pr-template.yaml
+    permissions:
+      contents: read
+      id-token: write
     with:
       package-path: ${{ matrix.package }}
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  packages: write
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -44,5 +40,7 @@ jobs:
         package: ${{ fromJson(needs.discover.outputs.matrix) }}
     uses: ./.github/workflows/publish-template.yml
     secrets: inherit
+    permissions:
+      contents: write
     with:
       package-path: ${{ matrix.package }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,5 +42,6 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+      id-token: write
     with:
       package-path: ${{ matrix.package }}

--- a/.github/workflows/publish-template.yml
+++ b/.github/workflows/publish-template.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           name: ${{ steps.get_metadata_from_csprojectfile.outputs.name }}
           version: ${{ steps.get_metadata_from_csprojectfile.outputs.version }}
-          source-feed: AT.Public.NuGet
+          source-feed: nuget
 
       - name: Publish package if not already published
         if: steps.nuget_version_check.outputs.published == 'false'

--- a/.github/workflows/publish-template.yml
+++ b/.github/workflows/publish-template.yml
@@ -30,10 +30,10 @@ jobs:
 
       - name: Publish package if not already published
         if: steps.nuget_version_check.outputs.published == 'false'
-        uses: Arbeidstilsynet/action-dotnet-publish@8d282653fd85f9a26e80d4f6a4c660eb5d6c8896 # v2
+        uses: Arbeidstilsynet/action-dotnet-publish@d1cc7810946ae13e76f109fab16a07bf75ec5917 # v3
         with:
           working-directory: ${{ inputs.package-path }}
-          nuget-auth-token: ${{ secrets.AZURE_DEVOPS_PUBLISH_PACKAGE_PAT }}
+          nuget-username: ${{ vars.NUGET_BOT_USERNAME }}
 
       # we don't want to create github prereleases to keep the release page clean
       - name: Check if version is prerelease

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.4.1-beta1</Version>
+    <Version>2.4.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -13,6 +13,7 @@
     <Version>2.4.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Arbeidstilsynet.Common.AspNetCore.Extensions" Version="2.1.3" />

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.4.0</Version>
+    <Version>2.4.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
+++ b/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 2.4.1
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 2.4.0
 
 ### Added

--- a/AltinnApp/AT.Common.AltinnApp.Publish/AT.Common.AltinnApp.Publish.csproj
+++ b/AltinnApp/AT.Common.AltinnApp.Publish/AT.Common.AltinnApp.Publish.csproj
@@ -11,7 +11,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Provides common functionality for usage in Altinn Apps</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.4.0</Version>
+    <Version>2.4.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/AltinnApp/AT.Common.AltinnApp.Publish/AT.Common.AltinnApp.Publish.csproj
+++ b/AltinnApp/AT.Common.AltinnApp.Publish/AT.Common.AltinnApp.Publish.csproj
@@ -14,6 +14,7 @@
     <Version>2.4.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Altinn.App.Core" Version="8.9.0" />

--- a/AltinnApp/AT.Common.AltinnApp.Publish/AT.Common.AltinnApp.Publish.csproj
+++ b/AltinnApp/AT.Common.AltinnApp.Publish/AT.Common.AltinnApp.Publish.csproj
@@ -11,7 +11,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Provides common functionality for usage in Altinn Apps</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.4.1-beta1</Version>
+    <Version>2.4.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/AltinnApp/AT.Common.AltinnApp.Publish/CHANGELOG.md
+++ b/AltinnApp/AT.Common.AltinnApp.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 2.4.1
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 2.4.0
 
 - changed: Differentiate structured data and main content.

--- a/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
@@ -13,6 +13,7 @@
     <Version>2.2.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />

--- a/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful extensions for cross-cutting concerns at Arbeidstilsynet</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.2.1-beta1</Version>
+    <Version>2.2.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/AT.Common.AspNetCore.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful extensions for cross-cutting concerns at Arbeidstilsynet</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.2.0</Version>
+    <Version>2.2.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/AspNetCore/AT.Common.AspNetCore.Publish/CHANGELOG.md
+++ b/AspNetCore/AT.Common.AspNetCore.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 2.2.1
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 2.2.0
 
 ### Changed

--- a/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/AT.Common.Enhetsregisteret.Publish.csproj
+++ b/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/AT.Common.Enhetsregisteret.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>A http client which interfaces with enhetsregisteret (Brønnøysundregistrene)</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.1-beta1</Version>
+    <Version>1.1.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/AT.Common.Enhetsregisteret.Publish.csproj
+++ b/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/AT.Common.Enhetsregisteret.Publish.csproj
@@ -13,6 +13,7 @@
     <Version>1.1.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Arbeidstilsynet.Common.AspNetCore.Extensions" Version="2.1.3" />

--- a/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/AT.Common.Enhetsregisteret.Publish.csproj
+++ b/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/AT.Common.Enhetsregisteret.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>A http client which interfaces with enhetsregisteret (Brønnøysundregistrene)</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>1.1.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/CHANGELOG.md
+++ b/Enhetsregisteret/AT.Common.Enhetsregisteret.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 1.1.1
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 1.1.0
 
 ### Changed

--- a/EraClient/AT.Common.EraClient.Publish/AT.Common.EraClient.Publish.csproj
+++ b/EraClient/AT.Common.EraClient.Publish/AT.Common.EraClient.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description></Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.2.3-beta1</Version>
+    <Version>2.2.3</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/EraClient/AT.Common.EraClient.Publish/AT.Common.EraClient.Publish.csproj
+++ b/EraClient/AT.Common.EraClient.Publish/AT.Common.EraClient.Publish.csproj
@@ -13,6 +13,7 @@
     <Version>2.2.3-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference

--- a/EraClient/AT.Common.EraClient.Publish/AT.Common.EraClient.Publish.csproj
+++ b/EraClient/AT.Common.EraClient.Publish/AT.Common.EraClient.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description></Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.2.2</Version>
+    <Version>2.2.3-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/EraClient/AT.Common.EraClient.Publish/CHANGELOG.md
+++ b/EraClient/AT.Common.EraClient.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 2.2.3
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 2.2.2
 
 ### Changed

--- a/FeatureFlags/AT.Common.FeatureFlags.Publish/AT.Common.FeatureFlags.Publish.csproj
+++ b/FeatureFlags/AT.Common.FeatureFlags.Publish/AT.Common.FeatureFlags.Publish.csproj
@@ -14,6 +14,7 @@
     <IsPublishable>true</IsPublishable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference

--- a/FeatureFlags/AT.Common.FeatureFlags.Publish/AT.Common.FeatureFlags.Publish.csproj
+++ b/FeatureFlags/AT.Common.FeatureFlags.Publish/AT.Common.FeatureFlags.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description></Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.2-beta1</Version>
+    <Version>1.1.2</Version>
     <IsPublishable>true</IsPublishable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>

--- a/FeatureFlags/AT.Common.FeatureFlags.Publish/AT.Common.FeatureFlags.Publish.csproj
+++ b/FeatureFlags/AT.Common.FeatureFlags.Publish/AT.Common.FeatureFlags.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description></Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.1</Version>
+    <Version>1.1.2-beta1</Version>
     <IsPublishable>true</IsPublishable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>

--- a/FeatureFlags/AT.Common.FeatureFlags.Publish/CHANGELOG.md
+++ b/FeatureFlags/AT.Common.FeatureFlags.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 1.1.2
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 1.1.1
 
 ### Changed

--- a/GeoNorge/AT.Common.GeoNorge.Publish/AT.Common.GeoNorge.Publish.csproj
+++ b/GeoNorge/AT.Common.GeoNorge.Publish/AT.Common.GeoNorge.Publish.csproj
@@ -13,6 +13,7 @@
     <Version>2.1.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Arbeidstilsynet.Common.AspNetCore.Extensions" Version="2.1.3" />

--- a/GeoNorge/AT.Common.GeoNorge.Publish/AT.Common.GeoNorge.Publish.csproj
+++ b/GeoNorge/AT.Common.GeoNorge.Publish/AT.Common.GeoNorge.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Implements a client which integrates with https://ws.geonorge.no/.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.1.1-beta1</Version>
+    <Version>2.1.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/GeoNorge/AT.Common.GeoNorge.Publish/AT.Common.GeoNorge.Publish.csproj
+++ b/GeoNorge/AT.Common.GeoNorge.Publish/AT.Common.GeoNorge.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Implements a client which integrates with https://ws.geonorge.no/.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.1.0</Version>
+    <Version>2.1.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/GeoNorge/AT.Common.GeoNorge.Publish/CHANGELOG.md
+++ b/GeoNorge/AT.Common.GeoNorge.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 2.1.1
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 2.1.0
 
 ### Changed

--- a/TestExtensions/AT.Common.TestExtensions.Publish/AT.Common.TestExtensions.Publish.csproj
+++ b/TestExtensions/AT.Common.TestExtensions.Publish/AT.Common.TestExtensions.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>A collection of useful patterns and extensions for unit testing in .NET.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.1-beta1</Version>
+    <Version>1.1.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/TestExtensions/AT.Common.TestExtensions.Publish/AT.Common.TestExtensions.Publish.csproj
+++ b/TestExtensions/AT.Common.TestExtensions.Publish/AT.Common.TestExtensions.Publish.csproj
@@ -13,6 +13,7 @@
     <Version>1.1.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WireMock.Net" Version="1.23.0" />

--- a/TestExtensions/AT.Common.TestExtensions.Publish/AT.Common.TestExtensions.Publish.csproj
+++ b/TestExtensions/AT.Common.TestExtensions.Publish/AT.Common.TestExtensions.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>A collection of useful patterns and extensions for unit testing in .NET.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>1.1.1-beta1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
   </PropertyGroup>

--- a/TestExtensions/AT.Common.TestExtensions.Publish/CHANGELOG.md
+++ b/TestExtensions/AT.Common.TestExtensions.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 1.1.1
+
+### Changed
+
+- chore: moved package to nuget.org
+
 ## 1.1.0
 
 ### Changed


### PR DESCRIPTION
resolves https://github.com/Arbeidstilsynet/team-plattform/issues/84

This will start publishing new versions in our new organization in nuget.org: https://www.nuget.org/profiles/Arbeidstilsynet

It uses https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing for safer and easier handling of tokens. The username passed to action-dotnet-publish has to configure trusted publishing policies.

Currently my user is used for publishing, but when our system user (nuget-bot) is in place I will simply remove the repo variable and add an organization variable in GitHub.

Personally I think this should simply be a patch increment. That should make Renovate simply upgrade from the new source automatically. Then consumers can remove AT.Public.Nuget from nuget.config when they no longer use it.

PS: Nuget displays readme and release notes separately, so now we can show both instead of just the changelog 😃