### PR TITLE
feat(altinn): add Validated property to AltinnSubscription response model

### DIFF
--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.0-alpha2</Version>
+    <Version>3.2.0-alpha1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.1</Version>
+    <Version>3.2.0-alpha1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.0-alpha1</Version>
+    <Version>3.2.0</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.0</Version>
+    <Version>3.2.0-alpha2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
+++ b/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 3.2.0-alpha1
+
+### Added
+
+- feat(altinn): Added `Validated` property to `AltinnSubscription` response model, indicating whether the subscription has been validated by Altinn.
+
 ## 3.1.1
 
 ### Fixed

--- a/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
+++ b/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
-## 3.2.0-alpha1
+## 3.2.0
 
 ### Added
 

--- a/Altinn/AT.Common.Altinn.Publish/Model/Api/Response/AltinnSubscription.cs
+++ b/Altinn/AT.Common.Altinn.Publish/Model/Api/Response/AltinnSubscription.cs
@@ -57,4 +57,10 @@ public class AltinnSubscription
     /// </summary>
     [JsonPropertyName("created")]
     public DateTime Created { get; set; }
+    
+    /// <summary>
+    /// Indicate whether the subscription has been validated to be ok.
+    /// </summary>
+    [JsonPropertyName("validated")]
+    public bool Validated { get; set; }
 }

--- a/Altinn/AT.Common.Altinn.Publish/Model/Api/Response/AltinnSubscription.cs
+++ b/Altinn/AT.Common.Altinn.Publish/Model/Api/Response/AltinnSubscription.cs
@@ -57,7 +57,7 @@ public class AltinnSubscription
     /// </summary>
     [JsonPropertyName("created")]
     public DateTime Created { get; set; }
-    
+
     /// <summary>
     /// Indicate whether the subscription has been validated to be ok.
     /// </summary>

--- a/Altinn/AT.Common.Altinn.Test/Unit/ClientTests/AltinnEventsClientTests.cs
+++ b/Altinn/AT.Common.Altinn.Test/Unit/ClientTests/AltinnEventsClientTests.cs
@@ -30,6 +30,7 @@ public class AltinnEventsClientTests : TestBed<AltinnApiTestFixture>
         //assert
         result.ShouldNotBeNull();
         result.TypeFilter.ShouldBe("app.instance.process.completed");
+        result.Validated.ShouldBe(true);
     }
 
     [Fact]
@@ -52,5 +53,6 @@ public class AltinnEventsClientTests : TestBed<AltinnApiTestFixture>
         //assert
         result.ShouldNotBeNull();
         result.TypeFilter.ShouldBe("app.instance.process.completed");
+        result.Validated.ShouldBe(true);
     }
 }

--- a/Altinn/AT.Common.Altinn.Test/Unit/TestData/openapi/altinn-platform-events-v1.json
+++ b/Altinn/AT.Common.Altinn.Test/Unit/TestData/openapi/altinn-platform-events-v1.json
@@ -1693,10 +1693,11 @@
           "typeFilter": "app.instance.process.completed",
           "consumer": "/user/12345",
           "createdBy": "/user/12345",
-          "created": "2022-07-27T13:14:14.395226Z"
+          "created": "2022-07-27T13:14:14.395226Z",
+          "validated": true
         }
       },
-      "SubscriptionList": {
+      "SubscriptionList":{
         "type": "object",
         "properties": {
           "count": {


### PR DESCRIPTION
## Summary

Adds the `Validated` (`bool`) property to the `AltinnSubscription` response model, reflecting whether Altinn has validated the subscription endpoint.

## Changes

- **`AltinnSubscription.cs`** — Added `Validated` property with `[JsonPropertyName("validated")]`
- **`altinn-platform-events-v1.json`** — Added `"validated": true` to the OpenAPI example so WireMock returns the field in integration tests
- **`AltinnEventsClientTests.cs`** — Added `result.Validated.ShouldBe(true)` assertions to `Subscribe` and `GetAltinnSubscription` tests
- **`AT.Common.Altinn.Publish.csproj`** — Bumped version to `3.2.0-alpha1`
- **`CHANGELOG.md`** — Added entry for `3.2.0-alpha1`