### PR TITLE
fix(altinn): fix NullReferenceException in GetSpecification when DataValues is null

### DIFF
--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.1</Version>
+    <Version>3.2.2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
+++ b/Altinn/AT.Common.Altinn.Publish/AT.Common.Altinn.Publish.csproj
@@ -10,7 +10,7 @@
     <Company>Arbeidstilsynet</Company>
     <Description>Useful methods and classes for cross-cutting concerns in Altinn applications</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>(Package release notes are in CHANGELOG.md)</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Arbeidstilsynet/dotnet-common</PackageProjectUrl>

--- a/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
+++ b/Altinn/AT.Common.Altinn.Publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security <!-- in case of vulnerabilities. -->
 
+## 3.2.1
+
+### Fixed
+
+- fix(altinn): `GetSpecification` no longer throws `NullReferenceException` when `DataValues` is `null` on an `AltinnInstance`
+
 ## 3.2.0
 
 ### Added

--- a/Altinn/AT.Common.Altinn.Publish/Extensions/AltinnSpecificationExtensions.cs
+++ b/Altinn/AT.Common.Altinn.Publish/Extensions/AltinnSpecificationExtensions.cs
@@ -25,8 +25,10 @@ internal static class AltinnSpecificationExtensions
 
         var resolvedSpec = new AltinnAppSpecification(sanitizedAppId);
 
+        var dataValues = instance.DataValues ?? [];
+
         if (
-            instance.DataValues.TryGetValue(StructuredDataTypeIdKey, out var val)
+            dataValues.TryGetValue(StructuredDataTypeIdKey, out var val)
             && val is { Length: > 0 } structuredDataTypeId
         )
         {
@@ -34,7 +36,7 @@ internal static class AltinnSpecificationExtensions
         }
 
         if (
-            instance.DataValues.TryGetValue(MainPdfDataTypeId, out val)
+            dataValues.TryGetValue(MainPdfDataTypeId, out val)
             && val is { Length: > 0 } mainPdfDataTypeId
         )
         {

--- a/Altinn/AT.Common.Altinn.Publish/Model/Api/Response/AltinnInstance.cs
+++ b/Altinn/AT.Common.Altinn.Publish/Model/Api/Response/AltinnInstance.cs
@@ -87,7 +87,7 @@ namespace Arbeidstilsynet.Common.Altinn.Model.Api.Response
         /// Gets or sets the data values for the instance.
         /// </summary>
         [JsonPropertyName("dataValues")]
-        public Dictionary<string, string> DataValues { get; set; }
+        public Dictionary<string, string> DataValues { get; set; } = new();
     }
 
     /// <summary>

--- a/Altinn/AT.Common.Altinn.Test/Unit/AltinnAppSpecificationTests.cs
+++ b/Altinn/AT.Common.Altinn.Test/Unit/AltinnAppSpecificationTests.cs
@@ -1,7 +1,7 @@
+using System.Text.Json;
 using Arbeidstilsynet.Common.Altinn.Extensions;
 using Arbeidstilsynet.Common.Altinn.Implementation.Adapter;
 using Arbeidstilsynet.Common.Altinn.Model.Api.Response;
-using System.Text.Json;
 using Shouldly;
 
 namespace Arbeidstilsynet.Common.Altinn.Test.Unit;

--- a/Altinn/AT.Common.Altinn.Test/Unit/AltinnAppSpecificationTests.cs
+++ b/Altinn/AT.Common.Altinn.Test/Unit/AltinnAppSpecificationTests.cs
@@ -56,6 +56,21 @@ public class AltinnAppSpecificationTests
     }
 
     [Fact]
+    public void GetSpecification_WhenDataValuesIsNull_DoesNotThrow()
+    {
+        var instance = new AltinnInstance
+        {
+            Id = Guid.NewGuid().ToString(),
+            AppId = "some-app-id",
+            Data = [],
+            DataValues = null!,
+        };
+
+        Action act = () => _ = instance.GetSpecification();
+        act.ShouldNotThrow();
+    }
+
+    [Fact]
     public void GetDataElementsBySignificance_WhenMainPdfIsMissing_Throws()
     {
         var instance = CreateInstance([]);


### PR DESCRIPTION
## Summary

Fixes a `NullReferenceException` thrown by `AltinnSpecificationExtensions.GetSpecification()` when an `AltinnInstance` has a `null` `DataValues` property.

This can happen in two scenarios:
- Altinn returns an instance response where the `dataValues` JSON field is absent (STJ leaves the property as `null`)
- Altinn returns `"dataValues": null` explicitly

## Changes

- **`AltinnInstance.cs`**: Initialize `DataValues` to an empty dictionary (`= new()`) so absent JSON fields don't leave it `null`
- **`AltinnSpecificationExtensions.cs`**: Null-coalesce `instance.DataValues` in `GetSpecification()` to guard against explicit `null` values
- **`AltinnAppSpecificationTests.cs`**: Added regression test `GetSpecification_WhenDataValuesIsNull_DoesNotThrow`
- **`AT.Common.Altinn.Publish.csproj`**: Version bumped `3.2.1` → `3.2.2`
- **`CHANGELOG.md`**: Added entry for `3.2.2`